### PR TITLE
test: Remaining fixups for reformat test scripts with autopep8

### DIFF
--- a/test/bt-handover
+++ b/test/bt-handover
@@ -48,7 +48,7 @@ def remove_paired_devices(bt_adapter):
                                        "org.bluez.Adapter1")
         break
 
-    if(bluez_adapter is None):
+    if (bluez_adapter is None):
         print("Bluetooth adapter %s could not be found" % bluez_adapter)
         exit()
 

--- a/test/phdc-simple-manager
+++ b/test/phdc-simple-manager
@@ -194,7 +194,7 @@ if "__main__" == __name__:
 try:
     mainloop.run()
 
-except(KeyboardInterrupt):
+except (KeyboardInterrupt):
     # Call for unregister...
     neard_manager.UnregisterAgent(simple_path, 'Manager')
     neard_manager.UnregisterAgent(valid_path, 'Manager')


### PR DESCRIPTION
Reformat the test/* and se/test/* scripts using the following command:

  $ autopep8 --in-place --aggressive test/* se/test/*